### PR TITLE
No account

### DIFF
--- a/lib/flippers.js
+++ b/lib/flippers.js
@@ -27,8 +27,15 @@ Flipper = {};
     var selector;
     if (Meteor.isServer) {
       // server-side needs filtering by user / group
-      userId = userId || Meteor.userId();
-      selector = _.extend(Flipper._selector(userId), { _id: this._id });
+      try {
+        userId = userId || Meteor.userId();
+        selector = _.extend(Flipper._selector(userId), { _id: this._id });
+      } catch (e) {
+        // likely called within a context that can't provide a userId
+        // so just no-op on extending _selector ... we can't know anything
+        // about the user so we're stuck with boolean gates only.
+        selector = { boolean: true };
+      }
     } else {
       // client-side is simple yes-no if present via publication against user
       selector = { _id: this._id };

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "User-level feature flippers",
-  version: "1.1.2",
+  version: "1.1.3",
   git: "https://github.com/rgm/meteor-flipper"
 });
 


### PR DESCRIPTION
Deals with uncaught exception where a flipper check is sitting in a block where Meteor.userId isn't available.
